### PR TITLE
Adjust styling to wrap around image on mobile

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -95,7 +95,7 @@ $ const linkLabel = input.storyLocation ? `story|${input.storyLocation}|${conten
                     </tr>
                     <tr>
                       <td>
-                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" class="hide_on_mobile">
+                        <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
                           <common-table-spacer-element height="5" />
                           <tr>
                             <td align="left" valign="top" style="font-family: 'Roboto', arial, sans-serif;font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
@@ -130,7 +130,7 @@ $ const linkLabel = input.storyLocation ? `story|${input.storyLocation}|${conten
           </td>
         </tr>
         <tr>
-          <td align="left" valign="top" class="show_on_mobile" style="display: none;mso-hide: all;">
+          <td align="left" valign="top" class="hide_on_mobile" style="display: none;mso-hide: all;">
             <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="mso-hide: all;">
               <common-table-spacer-element height="10" />
               <tr>


### PR DESCRIPTION
<img width="731" alt="Screen Shot 2023-03-27 at 10 30 00 AM" src="https://user-images.githubusercontent.com/64623209/227993380-336c9891-5895-4c18-9ea3-8cc40e753f4c.png">
<img width="535" alt="Screen Shot 2023-03-27 at 10 30 09 AM" src="https://user-images.githubusercontent.com/64623209/227993388-d0db3602-9da1-4535-acd3-d127e734273b.png">
<img width="782" alt="Screen Shot 2023-03-27 at 10 30 28 AM" src="https://user-images.githubusercontent.com/64623209/227993393-80844cfa-19a7-4a36-b668-7a3dd388d8a3.png">
