### PR TITLE
Adjust native ad size to 300x250

### DIFF
--- a/packages/common/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement.marko
@@ -41,8 +41,8 @@ $ const imgLinkStyles = {
                       <marko-newsletter-imgix
                         src=image.src
                         alt=image.alt
-                        options={ w: 540, h: 360, fit: "crop", auto: "format,compress" }
-                        attrs={ border: 0, width: 270, style: imgStyles }
+                        options={ w: 300, h: 250, fit: "crop", auto: "format,compress" }
+                        attrs={ border: 0, width: 300, style: imgStyles }
                       >
                         <@link href=url target="_blank" attrs={ style: imgLinkStyles } />
                       </marko-newsletter-imgix>
@@ -124,8 +124,8 @@ $ const imgLinkStyles = {
                       <marko-newsletter-imgix
                         src=image.src
                         alt=image.alt
-                        options={ w: 540, h: 360, fit: "crop", auto: "format,compress" }
-                        attrs={ border: 0, width: 270, style: imgStyles }
+                        options={ w: 300, h: 250, fit: "crop", auto: "format,compress" }
+                        attrs={ border: 0, width: 300, style: imgStyles }
                       >
                         <@link href=url target="_blank" attrs={ style: imgLinkStyles } />
                       </marko-newsletter-imgix>
@@ -196,8 +196,8 @@ $ const imgLinkStyles = {
                       <marko-newsletter-imgix
                         src=image.src
                         alt=image.alt
-                        options={ w: 540, h: 360, fit: "crop", auto: "format,compress" }
-                        attrs={ border: 0, width: 270, style: imgStyles }
+                        options={ w: 300, h: 250, fit: "crop", auto: "format,compress" }
+                        attrs={ border: 0, width: 300, style: imgStyles }
                       >
                         <@link href=url target="_blank" attrs={ style: imgLinkStyles } />
                       </marko-newsletter-imgix>
@@ -260,8 +260,8 @@ $ const imgLinkStyles = {
                       <marko-newsletter-imgix
                         src=image.src
                         alt=image.alt
-                        options={ w: 540, h: 360, fit: "crop", auto: "format,compress" }
-                        attrs={ border: 0, width: 270, style: imgStyles }
+                        options={ w: 300, h: 250, fit: "crop", auto: "format,compress" }
+                        attrs={ border: 0, width: 300, style: imgStyles }
                       >
                         <@link href=url target="_blank" attrs={ style: imgLinkStyles } />
                       </marko-newsletter-imgix>


### PR DESCRIPTION
<img width="800" alt="Screen Shot 2023-06-21 at 2 13 25 PM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/a26248e4-661f-448a-a9b4-59f18d83e303">
