### PR TITLE
Add ‘In Case You Missed It’ block to LFTE newsletters

### DIFF
--- a/packages/common/components/layouts/standard.marko
+++ b/packages/common/components/layouts/standard.marko
@@ -123,6 +123,18 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           />
         </if>
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="In Case You Missed It"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=false
+          limit=5
+        />
+
       </@body>
     </common-body-wrapper-block>
   </@body>

--- a/tenants/all/templates/am-lfte.marko
+++ b/tenants/all/templates/am-lfte.marko
@@ -133,6 +133,18 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           />
         </if>
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="In Case You Missed It"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=false
+          limit=5
+        />
+
       </@body>
     </common-body-wrapper-block>
   </@body>

--- a/tenants/all/templates/drb-lfte.marko
+++ b/tenants/all/templates/drb-lfte.marko
@@ -133,6 +133,18 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           />
         </if>
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="In Case You Missed It"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=false
+          limit=5
+        />
+
       </@body>
     </common-body-wrapper-block>
   </@body>


### PR DESCRIPTION
<img width="511" alt="Screen Shot 2023-10-16 at 9 24 11 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/c9d8cec8-8c8e-4925-9c5a-92d6cdac0e9e">
<img width="462" alt="Screen Shot 2023-10-16 at 9 24 32 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/0d1315bb-16cf-42db-9a7a-d4c4f4369d96">
<img width="489" alt="Screen Shot 2023-10-16 at 9 24 40 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/d1e3786d-64e2-4924-a5da-2b2c209e3877">
