### PR TITLE
Adjust rsna-preview layout to use section name ‘RSNA Preview’

### DIFF
--- a/tenants/all/templates/am-rsna-preview.marko
+++ b/tenants/all/templates/am-rsna-preview.marko
@@ -1,1 +1,67 @@
-<common-rsna-layout data=data />
+import { get } from "@parameter1/base-cms-object-path";
+import { parseBooleanHeader } from "@parameter1/base-cms-utils";
+import queryFragment from "@science-medicine-group/package-common/graphql/fragments/content-list";
+
+$ const { website, config, req } = out.global;
+$ const { newsletter, date } = data;
+
+$ const emailX = config.get("emailX");
+$ const nativeX = config.getAsObject("nativeX");
+
+<marko-newsletter-root
+  title=newsletter.name
+  description=newsletter.description
+  date=date
+>
+  <@head>
+    <common-head-block />
+  </@head>
+  <@body style="padding:0; margin:0;font-family: 'Roboto', Arial, sans-serif; -webkit-text-size-adjust:100%;">
+    <common-body-wrapper-block newsletter=newsletter date=date>
+      <@body>
+
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="RSNA Preview"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=true
+          limit=1
+        />
+
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          with-image=false
+          with-section=true
+          limit=1
+        />
+
+        <!-- Ad Slot 1 -->
+        <common-ad-wrapper-block
+          newsletter=newsletter
+          promotion-component="emailx-block"
+          ad-unit=emailX.getAdUnit({ name: 'ad-slot-1', alias: newsletter.alias })
+          date=date
+        />
+
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="Main"
+          newsletter=newsletter
+          with-image=false
+          with-section=true
+          limit=38
+          skip=1
+        />
+
+      </@body>
+    </common-body-wrapper-block>
+  </@body>
+</marko-newsletter-root>


### PR DESCRIPTION
<img width="561" alt="Screen Shot 2023-11-08 at 3 20 02 PM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/e98ce379-a46c-40c5-85ce-54da0c10e640">
