### PR TITLE
Move ‘Editor’s Note’ to top of Radcast layout

### DIFF
--- a/packages/common/components/layouts/radcast.marko
+++ b/packages/common/components/layouts/radcast.marko
@@ -25,6 +25,18 @@ $ const { id, alias, name, pageNode } = input;
         <!-- Content list block -->
         <common-content-list-block
           date=date
+          section-name="Editor's Note"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=true
+          limit=1
+        />
+
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
           section-name="Main"
           newsletter=newsletter
           with-image=true
@@ -62,18 +74,6 @@ $ const { id, alias, name, pageNode } = input;
           with-section=true
           skip=2
           limit=98
-        />
-
-        <!-- Content list block -->
-        <common-content-list-block
-          date=date
-          section-name="Editor's Note"
-          newsletter=newsletter
-          with-image=true
-          image-position="right"
-          with-header=true
-          continue-reading=true
-          limit=1
         />
 
       </@body>


### PR DESCRIPTION
<img width="724" alt="Screen Shot 2023-12-12 at 1 02 18 PM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/955f16ec-e408-4349-8055-a27b90b37ddd">
