### PR TITLE
Split up `preferenceCenterUrl` URL parameters

### DIFF
--- a/packages/common/components/blocks/am-lfte-footer.marko
+++ b/packages/common/components/blocks/am-lfte-footer.marko
@@ -16,7 +16,14 @@ $ const alt = defaultValue(input.alt, newsletter.name);
 
 $ const preferenceCenterUrl = buildLinkUrl(
   get(newsletterConfig, "preferenceCenter"),
-  { email: '{{${email_address} | url_encode }}&id={{${user_id}}}&subtitle=AuntMinnie%20Daily%20Newsletter&subID=6bbda052-75b3-4c48-bbbe-a943a1b7beac&subFlag=0&mode=edit' }
+  {
+    email: '{{${email_address} | url_encode }}',
+    id: '{{${user_id}}}',
+    subtitle: 'AuntMinnie%20Daily%20Newsletter',
+    subID: '6bbda052-75b3-4c48-bbbe-a943a1b7beac',
+    subFlag: '0',
+    mode: 'edit',
+  }
 );
 
 $ const standardStyle = {


### PR DESCRIPTION
![image](https://github.com/parameter1/science-medicine-group-newsletters/assets/46794001/0cb652d2-0e78-48e8-a719-d0e67fa24948)


https://my.auntminnie.com/unsubscribe-from-newsletter/?email={{${email_address}%20|%2[…]dit&braze_int_id={{${braze_id}}}&braze_ext_id={{${user_id}}}

vs

https://my.auntminnie.com/unsubscribe-from-newsletter/?email={{${email_address}%20|%2[…]dit&braze_int_id={{${braze_id}}}&braze_ext_id={{${user_id}}}