### PR TITLE
Add In Case You Missed It block to DrB Community Insider block

### DIFF
--- a/tenants/all/templates/drb-community-insider.marko
+++ b/tenants/all/templates/drb-community-insider.marko
@@ -90,6 +90,18 @@ $ const nativeX = config.getAsObject("nativeX");
           skip=5
         />
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="In Case You Missed It"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          header-background-color="#fbd043"
+          continue-reading=false
+          limit=5
+        />
       </@body>
     </common-body-wrapper-block>
   </@body>


### PR DESCRIPTION
<img width="730" alt="Screen Shot 2024-01-25 at 3 32 37 PM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/5d23c33e-a5db-4d17-a7c5-a6c71a8f466f">
