### PR TITLE
Move ‘Editor’s Note’ to top of AM-LFTE template

### DIFF
--- a/tenants/all/templates/am-lfte.marko
+++ b/tenants/all/templates/am-lfte.marko
@@ -35,6 +35,18 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
     <common-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
       <@body>
 
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
+          section-name="Editor's Note"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=true
+          continue-reading=true
+          limit=1
+        />
+
         <!-- RADCast section -->
         <common-content-list-block
           date=date
@@ -62,18 +74,6 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           with-section=true
           skip=3
           limit=7
-        />
-
-        <!-- Content list block -->
-        <common-content-list-block
-          date=date
-          section-name="Editor's Note"
-          newsletter=newsletter
-          with-image=true
-          image-position="right"
-          with-header=true
-          continue-reading=true
-          limit=1
         />
 
         <common-content-list-block


### PR DESCRIPTION
<img width="820" alt="Screenshot 2024-05-09 at 3 29 18 PM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/4a484471-7e16-4578-805b-dac7d0b05300">
