### PR TITLE
Remove ‘Content’ from ‘Sponsored by …’

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -74,7 +74,7 @@ $ const ctaLinkAttrs = { style: ctaLinkStyles, ...linkAttrs };
 
       $ const labels = getAsArray(content, "labels");
       <if(labels.includes("Sponsored"))>
-        $ const tag = (content.company) ? `Sponsored Content by ${get(content, "company.name")}` : "Sponsored Content";
+        $ const tag = (content.company) ? `Sponsored by ${get(content, "company.name")}` : "Sponsored Content";
         <tr>
           <td align="left" valign="top" style=sponsoredTagStyle>${tag}</td>
           <td align="right" width="200">


### PR DESCRIPTION
<img width="593" alt="Screenshot 2024-05-16 at 9 13 07 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/36f68880-1455-4f86-a2a1-ca6d4976d61a">
