### PR TITLE
Replace 25 for 25 Native ad to content block

### DIFF
--- a/tenants/all/templates/am-lfte.marko
+++ b/tenants/all/templates/am-lfte.marko
@@ -181,12 +181,15 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           limit=5
         />
 
-        <!-- 25 FOR 25 Native block -->
-        <common-ad-wrapper-block
+        <!-- Content list block -->
+        <common-content-list-block
           date=date
+          section-name="25 For 25"
           newsletter=newsletter
-          promotion-component="25-for-25-block"
-          placement-id=get(nativeX, `placements.${newsletter.alias}.sponsored`)
+          with-image=false
+          with-header=true
+          continue-reading=false
+          limit=1
         />
 
       </@body>

--- a/tenants/all/templates/am-weekly.marko
+++ b/tenants/all/templates/am-weekly.marko
@@ -167,11 +167,15 @@ $ const resolvedToNodesConverter = ({ resolved }) => (resolved.map((node) => ({
           limit=10
         />
 
-        <common-ad-wrapper-block
+        <!-- Content list block -->
+        <common-content-list-block
           date=date
+          section-name="25 For 25"
           newsletter=newsletter
-          promotion-component="25-for-25-block"
-          placement-id=get(nativeX, `placements.${newsletter.alias}.sponsored`)
+          with-image=false
+          with-header=true
+          continue-reading=false
+          limit=1
         />
 
       </@body>


### PR DESCRIPTION
<img width="798" alt="Screenshot 2024-06-27 at 9 17 34 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/1ed930a1-1658-40b0-9f89-2d77966ef48d">
<img width="847" alt="Screenshot 2024-06-27 at 9 17 22 AM" src="https://github.com/parameter1/science-medicine-group-newsletters/assets/64623209/fd85fc01-3198-42ab-9810-3456954f8a5d">
