### PR TITLE
Fix ‘Sponsored’ article error

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -78,14 +78,16 @@ $ const ctaLinkAttrs = { style: ctaLinkStyles, ...linkAttrs };
         <tr>
           <td align="left" valign="top" style=sponsoredTagStyle>${tag}</td>
           <td align="right" width="200">
-            <marko-newsletter-imgix
-              src=advertiser.image.src
-              alt=advertiser.image.alt
-              options={ w: 360, auto: "format,compress" }
-              attrs={ border: 0, width: 180 }
-            >
-              <@link href=advertiser.website target="_blank" attrs=imgLinkAttrs />
-            </marko-newsletter-imgix>
+            <marko-core-obj-value|{ value: image }| obj=content.company field="primaryImage" as="object">
+              <marko-newsletter-imgix
+                src=image.src
+                alt=image.alt
+                options={ w: 360, auto: "format,compress" }
+                attrs={ border: 0, width: 180 }
+              >
+                <@link href=url target="_blank" attrs=imgLinkAttrs />
+              </marko-newsletter-imgix>
+            </marko-core-obj-value>
           </td>
         </tr>
       </if>
@@ -96,7 +98,9 @@ $ const ctaLinkAttrs = { style: ctaLinkStyles, ...linkAttrs };
       </else-if>
 
       <common-table-spacer-element height="6" />
+    </table>
 
+    <table role="presentation" width="610" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
       <if(withImage && imagePosition === 'top' && content.primaryImage)>
         <common-table-spacer-element height="6" />
         <tr>


### PR DESCRIPTION
img wasn’t defined

<img width="774" alt="Screenshot 2024-09-23 at 8 36 09 PM" src="https://github.com/user-attachments/assets/caf1b518-ac6d-4f00-a430-0a6c3a3d5f35">
