### PR TITLE
Remove section tags from Sponsored & Conference newsletters

### DIFF
--- a/packages/common/components/layouts/radcast.marko
+++ b/packages/common/components/layouts/radcast.marko
@@ -41,7 +41,7 @@ $ const { id, alias, name, pageNode } = input;
           newsletter=newsletter
           with-image=true
           image-position="right"
-          with-section=true
+          with-section=false
           limit=1
           skip=0
         />
@@ -52,7 +52,7 @@ $ const { id, alias, name, pageNode } = input;
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           limit=1
           skip=1
         />
@@ -74,7 +74,7 @@ $ const { id, alias, name, pageNode } = input;
           newsletter=newsletter
           with-image=true
           image-position="right"
-          with-section=true
+          with-section=false
           skip=2
           limit=1
         />
@@ -85,7 +85,7 @@ $ const { id, alias, name, pageNode } = input;
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           skip=3
           limit=30
         />

--- a/packages/common/components/layouts/senl.marko
+++ b/packages/common/components/layouts/senl.marko
@@ -29,7 +29,7 @@ $ const { id, alias, name, pageNode } = input;
           newsletter=newsletter
           with-image=true
           image-position=false
-          with-section=true
+          with-section=false
           limit=1
           skip=0
         />
@@ -48,7 +48,7 @@ $ const { id, alias, name, pageNode } = input;
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           limit=1
           skip=1
         />
@@ -67,7 +67,7 @@ $ const { id, alias, name, pageNode } = input;
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           skip=2
           limit=1
         />

--- a/tenants/all/templates/am-rsna-preview.marko
+++ b/tenants/all/templates/am-rsna-preview.marko
@@ -56,7 +56,7 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           limit=23
           skip=1
         />

--- a/tenants/all/templates/am-rsna-preview.marko
+++ b/tenants/all/templates/am-rsna-preview.marko
@@ -38,7 +38,7 @@ $ const nativeX = config.getAsObject("nativeX");
           section-name="Main"
           newsletter=newsletter
           with-image=false
-          with-section=true
+          with-section=false
           limit=1
         />
 

--- a/tenants/all/templates/ame-radcast.marko
+++ b/tenants/all/templates/ame-radcast.marko
@@ -41,7 +41,7 @@ $ const { id, alias, name, pageNode } = input;
           newsletter=newsletter
           with-image=true
           image-position="right"
-          with-section=true
+          with-section=false
           limit=2
           skip=0
         />
@@ -62,7 +62,7 @@ $ const { id, alias, name, pageNode } = input;
           newsletter=newsletter
           with-image=true
           image-position="right"
-          with-section=true
+          with-section=false
           skip=2
         />
 


### PR DESCRIPTION
[https://trello.com/c/uRO2HZ14/719-radcast-newsletter-drop-tags](url)

<img width="607" alt="Screenshot 2025-04-25 at 2 19 34 PM" src="https://github.com/user-attachments/assets/8fd07e73-8397-4b47-8b95-031141740142" />
<img width="612" alt="Screenshot 2025-04-25 at 2 19 46 PM" src="https://github.com/user-attachments/assets/bcc78e3a-00ec-42c0-8db1-b67e78fb2ed0" />
<img width="665" alt="Screenshot 2025-04-25 at 2 20 30 PM" src="https://github.com/user-attachments/assets/28a65a9d-c940-4075-a29c-cd5806ddf599" />
<img width="633" alt="Screenshot 2025-04-25 at 2 19 59 PM" src="https://github.com/user-attachments/assets/af74c7bf-0cdc-4b61-8e4d-c98d26ad19c4" />
