### PR TITLE
Switch between braze/mc vars based on channel config

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -1,10 +1,12 @@
 import { getAsObject } from "@mindful-web/object-path";
+import { getTokens } from "@science-medicine-group/package-common/utils/esp-tokens";
 
 $ const adUnit = getAsObject(input, "adUnit");
+$ const espTokens = getTokens(out.global.emailProvider);
 
 <marko-newsletters-email-x-data|{ response }| decoded-params=['email', 'send']>
   <@ad-unit ...adUnit />
-  <@params date=input.date email="{{\${braze_id}}}" />
+  <@params date=input.date email=espTokens.emailxEmail />
   <if(response)>
     <tr>
       <td align="center" valign="top">

--- a/packages/common/components/blocks/ad/promotion-advertisement/layout-a.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement/layout-a.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -15,7 +15,7 @@ $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
 
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const label = input.label || "Paid Advertisement";
 
 $ const imgStyles = {

--- a/packages/common/components/blocks/ad/promotion-advertisement/layout-b.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement/layout-b.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -15,7 +15,7 @@ $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
 
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const label = input.label || "Paid Advertisement";
 
 $ const imgStyles = {

--- a/packages/common/components/blocks/ad/promotion-advertisement/layout-c.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement/layout-c.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -15,7 +15,7 @@ $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
 
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const label = input.label || "Paid Advertisement";
 
 $ const imgStyles = {

--- a/packages/common/components/blocks/ad/promotion-advertisement/layout-default.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement/layout-default.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -15,7 +15,7 @@ $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
 
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const label = input.label || "Paid Advertisement";
 
 $ const imgStyles = {

--- a/packages/common/components/blocks/ad/promotion-company.marko
+++ b/packages/common/components/blocks/ad/promotion-company.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -14,7 +14,7 @@ $ const since = reqDate ? moment(reqDate).add(1, 'd').valueOf() : moment().add(1
 $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 
 $ const imgStyles = {
   "font-size": "14px",

--- a/packages/common/components/blocks/ad/promotion-sponsored.marko
+++ b/packages/common/components/blocks/ad/promotion-sponsored.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get, getAsObject } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -14,7 +14,7 @@ $ const since = reqDate ? moment(reqDate).add(1, 'd').valueOf() : moment().add(1
 $ const creativeId = get(input, "creativeId");
 $ const tenant = get(input, "tenant");
 $ const content = getAsObject(input, "content");
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 
 $ const imgStyles = {
   "font-size": "14px",

--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 $ const { newsletter, date } = input;
 
 $ const unixTimestamp = moment(date).unix();
-$ const stealthLinkUrl = `${newsletter.site.origin}/email-preview/${newsletter.id}/${unixTimestamp}`;
+$ const stealthLinkUrl = `${newsletter?.site?.origin}/email-preview/${newsletter.id}/${unixTimestamp}`;
 
 <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
   <tr>

--- a/packages/common/components/blocks/content/25-for-25.marko
+++ b/packages/common/components/blocks/content/25-for-25.marko
@@ -4,7 +4,7 @@ import { get, getAsArray, getAsObject } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -15,7 +15,7 @@ $ const since = reqDate ? moment(reqDate).add(1, 'd').valueOf() : moment().add(1
 $ const { content, ctaLinkStyle, advertiser } = input;
 $ const creativeId = get(input, "mindfulCreativeId");
 $ const tenant = get(input, "mindfulTenant");
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 
 $ const imgLinkStyles = {
   "font-family": "'Roboto', arial, sans-serif",

--- a/packages/common/components/blocks/content/api-list-item.marko
+++ b/packages/common/components/blocks/content/api-list-item.marko
@@ -4,7 +4,7 @@ import { get, getAsArray } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -13,7 +13,7 @@ $ const utm_source = get(newsletterConfig, "name");
 $ const since = reqDate ? moment(reqDate).add(1, 'd').valueOf() : moment().add(1, 'd').valueOf();
 
 $ const { content, ctaLinkStyle } = input;
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const withImage = defaultValue(input.withImage, true);
 $ const imagePosition = defaultValue(input.imagePosition, 'right');
 

--- a/packages/common/components/blocks/content/background.marko
+++ b/packages/common/components/blocks/content/background.marko
@@ -5,7 +5,7 @@ import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import queryFragment from "@science-medicine-group/package-common/graphql/fragments/content-list";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletter = getAsObject(input, "newsletter");
 $ const { sectionName, date } = input;
@@ -64,7 +64,7 @@ $ const imgLinkStyles = {
                       attrs={ border: 0, width: 580, align: "center", vspace: 5, style: imgStyles }
                     >
                       <@link
-                        href=buildLinkUrl(content.siteContext.url, { utm_campaign, utm_source })
+                        href=buildLinkUrl(content.siteContext.url, { utm_campaign, utm_source }, emailProvider)
                         target="_blank"
                         attrs={ style: imgLinkStyles }
                       />
@@ -89,7 +89,7 @@ $ const imgLinkStyles = {
               <tr>
                 <td align="left" valign="top">
                   <a
-                    href=buildLinkUrl(content.linkUrl, { utm_campaign, utm_source })
+                    href=buildLinkUrl(content.linkUrl, { utm_campaign, utm_source }, emailProvider)
                     style="font-size: 18px;line-height: 23px;color: #055c9d;font-family: 'Roboto', Arial, sans-serif;padding: 0 15px;text-decoration: none;"
                     target="_blank"
                   >

--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -4,7 +4,7 @@ import { get, getAsArray, getAsObject } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -16,7 +16,7 @@ $ const { content, ctaLinkStyle, advertiser } = input;
 $ const company = (advertiser) ? advertiser : content.company;
 $ const creativeId = get(input, "mindfulCreativeId");
 $ const tenant = get(input, "mindfulTenant");
-$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since });
+$ const url = buildLinkUrl(get(content, "siteContext.url"), { utm_campaign, utm_source, since }, emailProvider);
 $ const withImage = defaultValue(input.withImage, true);
 $ const imagePosition = defaultValue(input.imagePosition, 'right');
 $ const withSection = defaultValue(input.withSection, false);

--- a/packages/common/components/blocks/footer.marko
+++ b/packages/common/components/blocks/footer.marko
@@ -3,8 +3,10 @@ import moment from "moment";
 import { get, getAsObject, getAsArray } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
+import { getTokens } from '@science-medicine-group/package-common/utils/esp-tokens';
 
-$ const { website, config, req } = out.global;
+$ const { website, config, req, emailProvider } = out.global;
+$ const espTokens = getTokens(emailProvider);
 $ const { newsletter } = input;
 $ const newsletterConfig = config.get(newsletter.alias);
 
@@ -15,13 +17,14 @@ $ const tagline = get(newsletterConfig, "tagline");
 $ const subscribeLink = get(newsletterConfig, "subscribeLink");
 $ const publicationName = get(newsletterConfig, "publicationName");
 $ const footerWidth = defaultValue(get(newsletterConfig, "logo.footerWidth"), 130);
-$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source });
+$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source }, emailProvider);
 $ const logoFooterSrc = newsletterConfig.logo.footerSrc;
 $ const alt = defaultValue(input.alt, newsletter.name);
 
-$ const preferenceCenterUrl = buildLinkUrl(
+$ const preferenceCenterUrl = espTokens.unsubscribeUrl || buildLinkUrl(
   get(newsletterConfig, "preferenceCenter"),
-  { email: '{{${email_address} | url_encode }}', utm_campaign, utm_source }
+  { email: espTokens.email, utm_campaign, utm_source },
+  emailProvider
 );
 
 $ const standardStyle = {
@@ -162,7 +165,7 @@ $ const stealthLinkStyle = {
                   <tr>
                     <td align="left" valign="top" style=standardStyle>
                       <for|link, index| of=contactLinks>
-                        <a href=buildLinkUrl(link.href, { utm_campaign, utm_source }) style=standardUnderlineStyle>
+                        <a href=buildLinkUrl(link.href, { utm_campaign, utm_source }, emailProvider) style=standardUnderlineStyle>
                           ${link.label}
                         </a>
                         <if(index < (contactLinks.length - 1))>

--- a/packages/common/components/blocks/new-footer.marko
+++ b/packages/common/components/blocks/new-footer.marko
@@ -2,8 +2,10 @@ import moment from "moment";
 import { get, getAsObject, getAsArray } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
+import { getTokens } from '@science-medicine-group/package-common/utils/esp-tokens';
 
-$ const { website, config, req } = out.global;
+$ const { website, config, req, emailProvider } = out.global;
+$ const espTokens = getTokens(emailProvider);
 $ const { newsletter } = input;
 
 $ const newsletterConfig = config.get(newsletter.alias);
@@ -16,22 +18,23 @@ $ const subtitle = get(newsletterConfig, "subtitle");
 $ const subID = get(newsletterConfig, "subID");
 $ const publicationName = get(newsletterConfig, "publicationName");
 $ const footerWidth = defaultValue(get(newsletterConfig, "logo.footerWidth"), 130);
-$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source });
+$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source }, emailProvider);
 $ const logoFooterSrc = newsletterConfig.logo.footerSrc;
 $ const alt = defaultValue(input.alt, newsletter.name);
 
-$ const preferenceCenterUrl = buildLinkUrl(
+$ const preferenceCenterUrl = espTokens.unsubscribeUrl || buildLinkUrl(
   get(newsletterConfig, "preferenceCenter"),
   {
-    email: '{{${email_address} | url_encode }}',
-    id: '{{${user_id}}}',
+    email: espTokens.email,
+    id: espTokens.userId,
     subtitle,
     subID,
     subFlag: '0',
     mode: 'edit',
     utm_campaign,
     utm_source,
-  }
+  },
+  emailProvider
 );
 
 $ const standardStyle = {
@@ -157,7 +160,7 @@ $ const stealthLinkStyle = {
                   <tr>
                     <td align="left" valign="top" style=standardStyle>
                       <for|link, index| of=contactLinks>
-                        <a href=buildLinkUrl(link.href, { utm_campaign, utm_source }) style=standardUnderlineStyle>
+                        <a href=buildLinkUrl(link.href, { utm_campaign, utm_source }, emailProvider) style=standardUnderlineStyle>
                           ${link.label}
                         </a>
                         <if(index < (contactLinks.length - 1))>

--- a/packages/common/components/blocks/view-online.marko
+++ b/packages/common/components/blocks/view-online.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { website, config, req } = out.global;
+$ const { website, config, req, emailProvider } = out.global;
 
 $ const reqDate = Number(get(req, "query.date"));
 $ const utm_campaign = reqDate ? moment(reqDate).format("YYYY-MM-DD") : moment().format("YYYY-MM-DD");
@@ -17,7 +17,9 @@ $ const utm_source = get(newsletterConfig, "name");
         <common-table-spacer-element height="13" />
         <tr>
           <td align="center" valign="middle" style="font-size:15px;line-height:19px; color:#62626c;font-weight:400;">
-            <a href=buildLinkUrl(website.get("origin"), { utm_campaign, utm_source }) style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+          <if(website)>
+            <a href=buildLinkUrl(website.get("origin"), { utm_campaign, utm_source }, emailProvider) style="text-decoration: none;color: #62626c;">${website.get("name")}</a>
+          </if>
           </td>
         </tr>
         <common-table-spacer-element height="10" />

--- a/packages/common/components/elements/link.marko
+++ b/packages/common/components/elements/link.marko
@@ -3,7 +3,7 @@ import moment from "moment";
 import { get } from "@mindful-web/object-path";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { config, req } = out.global;
+$ const { config, req, emailProvider } = out.global;
 
 $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
@@ -23,7 +23,7 @@ $ const linkStyle = {
 
 <tr>
   <td align="left" valign="top">
-    <a style=linkStyle href=buildLinkUrl(linkUrl, { utm_campaign, utm_source }) linklabel=linkLabel>
+    <a style=linkStyle href=buildLinkUrl(linkUrl, { utm_campaign, utm_source }, emailProvider) linklabel=linkLabel>
       ${linkText}
     </a>
   </td>

--- a/packages/common/components/elements/logo.marko
+++ b/packages/common/components/elements/logo.marko
@@ -4,7 +4,7 @@ import { get } from "@mindful-web/object-path";
 import defaultValue from "@mindful-web/marko-core/utils/default-value";
 import buildLinkUrl from '@science-medicine-group/package-common/utils/build-link-url';
 
-$ const { website, config, req } = out.global;
+$ const { website, config, req, emailProvider } = out.global;
 
 $ const { newsletter, width } = input;
 
@@ -14,7 +14,7 @@ $ const newsletterConfig = config.get(req.path.slice(1));
 $ const reqDate = Number(get(req, "query.date"));
 $ const utm_campaign = reqDate ? moment(reqDate).format("YYYY-MM-DD") : moment().format("YYYY-MM-DD");
 $ const utm_source = get(newsletterConfig, "name");
-$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source });
+$ const url = buildLinkUrl(website.get("origin"), { utm_campaign, utm_source }, emailProvider);
 $ const logoSrc = newsletterConfig.logo.src;
 
 $ const alt = defaultValue(input.alt, newsletter.name);

--- a/packages/common/utils/build-link-url.js
+++ b/packages/common/utils/build-link-url.js
@@ -1,19 +1,17 @@
-/* eslint-disable no-template-curly-in-string */
+const { getTokens, isMailchimp } = require('./esp-tokens');
+
 const liquidVar = /{{.*?}}/;
 const isObj = (v) => typeof v === 'object';
 
-const alwaysAppend = {
-  braze_int_id: '{{${braze_id}}}',
-  braze_ext_id: '{{${user_id}}}',
-  utm_medium: 'email',
-};
-
-module.exports = (href, params = {}) => {
+module.exports = (href, params, provider) => {
   const url = new URL(href);
-  const toAppend = { ...(isObj(params) && { ...params }), ...alwaysAppend };
+  const toAppend = { ...(isObj(params) && { ...params }), ...getTokens(provider).linkParams };
 
   // Set append the values to the URL
   Object.entries(toAppend).forEach(([key, value]) => { url.searchParams.set(key, value); });
+
+  // Un-escape merge-tag pipes so Mailchimp can replace them.
+  if (isMailchimp(provider)) return `${url}`.replace(/%7C/ig, '|');
 
   let encoded = `${url}`;
   // Decode any liquid tags to ensure successful replacement.

--- a/packages/common/utils/esp-tokens.js
+++ b/packages/common/utils/esp-tokens.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-template-curly-in-string */
+const BRAZE = 'braze';
+const MAILCHIMP = 'mailchimp';
+
+const TOKENS = {
+  [BRAZE]: {
+    // When null, footers build the unsubscribe link from the newsletter's
+    // configured `preferenceCenter` URL + params.
+    unsubscribeUrl: null,
+    email: '{{${email_address} | url_encode }}',
+    userId: '{{${user_id}}}',
+    emailxEmail: '{{${braze_id}}}',
+    // Appended to every link. Key order matters: it determines query param
+    // order in the rendered URLs.
+    linkParams: {
+      braze_int_id: '{{${braze_id}}}',
+      braze_ext_id: '{{${user_id}}}',
+      utm_medium: 'email',
+    },
+  },
+  [MAILCHIMP]: {
+    // Used verbatim as the unsubscribe href (no params appended).
+    unsubscribeUrl: '*|UNSUB|*',
+    email: '*|URL:EMAIL|*',
+    userId: '*|UNIQID|*',
+    emailxEmail: '*|UNIQID|*',
+    linkParams: {
+      mc_id: '*|UNIQID|*',
+      utm_medium: 'email',
+    },
+  },
+};
+
+const resolve = (provider) => (TOKENS[provider] ? provider : BRAZE);
+
+module.exports = {
+  BRAZE,
+  MAILCHIMP,
+  SUPPORTED: Object.keys(TOKENS),
+  resolve,
+  getTokens: (provider) => TOKENS[resolve(provider)],
+  isMailchimp: (provider) => resolve(provider) === MAILCHIMP,
+};

--- a/tenants/all/config/custom.js
+++ b/tenants/all/config/custom.js
@@ -1,1 +1,20 @@
-module.exports = {};
+const { get } = require('@mindful-web/object-path');
+const { SUPPORTED, BRAZE } = require('@science-medicine-group/package-common/utils/esp-tokens');
+
+module.exports = {
+  // Resolves the email service provider for the requested newsletter and
+  // exposes it to all components as `out.global.emailProvider`.
+  onBeforeRenderHook: async ({ req, res, templateData }) => {
+    // ?esp=mailchimp|braze preview override, else the newsletter's provider
+    // type from the CMS, else braze.
+    const qs = `${get(req, 'query.esp') || ''}`.toLowerCase();
+    const type = `${get(templateData, 'newsletter.provider.type') || ''}`.toLowerCase();
+    let emailProvider = BRAZE;
+    if (SUPPORTED.includes(qs)) {
+      emailProvider = qs;
+    } else if (SUPPORTED.includes(type)) {
+      emailProvider = type;
+    }
+    res.locals.emailProvider = emailProvider;
+  },
+};

--- a/tenants/all/index.js
+++ b/tenants/all/index.js
@@ -10,6 +10,7 @@ module.exports = startServer({
   coreConfig,
   customConfig,
   publicPath: 'public',
+  newsletterQueryFragment: 'fragment NewsletterProviderFragment on EmailNewsletter { provider { type } }',
   onStart: (app) => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
   onAsyncBlockError: (e) => newrelic.noticeError(e),
 }).then(() => log('Newsletters started!')).catch((e) => setImmediate(() => { throw e; }));


### PR DESCRIPTION
## Summary

SMG is migrating from Braze to Mailchimp in phases (AM/AMEU first, DRB a few weeks later). This makes the merge-variable syntax per-newsletter dynamic, driven by the newsletter's `provider.type` from the platform — so each cutover is a data update (`updateEmailNewsletterProvider` mutation), **not a code deploy**.

- **`packages/common/utils/esp-tokens.js`** (new): single source of truth for every ESP-specific string (Braze Liquid tokens vs Mailchimp merge tags). Unknown/`omeda`/`null` provider types resolve to `braze`, preserving current behavior everywhere.
- **`build-link-url.js`**: takes the provider as a third arg. Braze path is byte-identical to before; Mailchimp mode appends `mc_id=*|UNIQID|*` + `utm_medium=email` (existing per-newsletter `utm_campaign`/`utm_source` values are preserved) and un-escapes merge-tag pipes.
- **`tenants/all/index.js`**: passes `newsletterQueryFragment` so the render query fetches `provider { type }` (built-in framework hook — no upstream changes).
- **`tenants/all/config/custom.js`**: `onBeforeRenderHook` resolves the ESP per request and exposes it as `out.global.emailProvider`. A `?esp=mailchimp|braze` query param overrides for previewing/QA.
- **Footers**: in Mailchimp mode the unsubscribe link is the raw `*|UNSUB|*` tag (no preference-center URL/params); Braze mode unchanged.
- **EmailX ad block**: passes `*|UNIQID|*` instead of `{{${braze_id}}}` in Mailchimp mode.
- Remaining `buildLinkUrl` call sites mechanically thread `emailProvider` through. An omitted arg falls back to Braze, so a missed call site degrades to current behavior.

## Verification

- Unit-compared old vs new `build-link-url`: Braze output byte-identical across edge cases.
- Rendered `am-lfte`, `drb-lfte`, `am-breaking-news`, `labpulse-lfte` (omeda), `drb-cds` (null provider), `sab` (static) before/after against the virgon API: byte-identical except rotating ad creatives (confirmed pre-existing nondeterminism by diffing two consecutive same-code renders).
- `?esp=mailchimp`: every link carries `mc_id=*|UNIQID|*` with literal pipes, exactly one `*|UNSUB|*` unsubscribe href, zero `{{` liquid tokens, zero `braze_` params. `?esp=braze` matches the default render.
- `yarn lint && yarn compile` pass.

## Rollout

1. This PR is behavior-neutral — every newsletter still renders Braze tokens until its provider record changes.
2. QA each newsletter pre-cutover with `?esp=mailchimp`.
3. Per phase, set `provider.type: 'mailchimp'` per newsletter via `updateEmailNewsletterProvider`; rendering flips on the next request. Rollback = revert the mutation.